### PR TITLE
fix: the aggregation to work on our k8s cluster

### DIFF
--- a/server/app/core/tests/test_usecases.py
+++ b/server/app/core/tests/test_usecases.py
@@ -178,7 +178,10 @@ async def test_aggregate_catalog_responses():
     ) as mock_query_peer_services:
         mock_query_peer_services.return_value = mock_peer_response
         result = await usecases.aggregate_catalog_responses(mock_query)
-        assert len(result) == 3  # 1 local response + 2 peer responses
+        # assert len(result) == 3  # 1 local response + 2 peer responses
+        assert (
+            len(result) == 2
+        )  # 2 peer responses only, local response is not included in the list
         assert all(isinstance(graph, Graph) for graph in result)
         assert "@context" in mock_response
         assert "@graph" in mock_response

--- a/server/app/core/usecases.py
+++ b/server/app/core/usecases.py
@@ -113,8 +113,8 @@ class SearchUsecases:
         logger.info("Starting aggregation of catalog responses")
 
         # Query the local catalog
-        local_response = await self.query_local_catalog(query)
-        logger.debug(f"Local response: {local_response.serialize(format='json-ld')}")
+        # local_response = await self.query_local_catalog(query)
+        # logger.debug(f"Local response: {local_response.serialize(format='json-ld')}")
 
         # Discover and query peer services
         peer_services = await self.discover_peer_services()
@@ -125,7 +125,8 @@ class SearchUsecases:
         logger.info(f"Received {len(peer_responses)} responses from peer services")
 
         # Combine all responses into a list of Graphs
-        aggregated_graphs = [local_response]
+        # aggregated_graphs = [local_response]
+        aggregated_graphs = []
         aggregated_graphs.extend(peer_responses)
 
         logger.info(f"Aggregated {len(aggregated_graphs)} graphs in total")


### PR DESCRIPTION
## Summary
This is a fix for aggregating the results, as resolving the IP of the node on our k8s is not working as expected, which is causing duplicates

## Issue
[here](https://hiro-microdatacenters-team.atlassian.net/browse/DS-48)

## Changes
- Update the use case to remove the local response and just use the peers
- Update the related test